### PR TITLE
Update non-Windows ifdef typo in msxcompiler.c

### DIFF
--- a/Src/msxcompiler.c
+++ b/Src/msxcompiler.c
@@ -131,7 +131,7 @@ int MSXcompiler_open()
         }
         else return ERR_COMPILE_FAILED;
 #else
-        if ( wiMSX.Compiler == GC )
+        if ( MSX.Compiler == GC )
         {
             sprintf(cmd, "gcc -c -fPIC -O3 %s", srcFile);
             err = system(cmd);


### PR DESCRIPTION
Error in non-windows section of code. Tries to access non-existent variable, looks like someone accidentally typed in the wrong place but didn't realize it because it was in an IFDEF section.