### PR TITLE
Added two pass-through functions for ENopen and ENclose

### DIFF
--- a/src/solver/include/epanetmsx.h
+++ b/src/solver/include/epanetmsx.h
@@ -9,6 +9,8 @@
 **  LAST UPDATE:   11/01/10
 *******************************************************************************/
 
+#include "epanet2.h"                   // EPANET toolkit header file
+
 #ifndef EPANETMSX_H
 #define EPANETMSX_H
 
@@ -53,6 +55,8 @@ extern "C" {
 
 // --- declare MSX functions
 
+int  MSXDLLEXPORT MSXENopen(const char *inpFile, const char *rptFile,
+                 const char *outFile);
 int  MSXDLLEXPORT MSXopen(char *fname);
 int  MSXDLLEXPORT MSXsolveH(void);
 int  MSXDLLEXPORT MSXusehydfile(char *fname);
@@ -63,6 +67,7 @@ int  MSXDLLEXPORT MSXsaveoutfile(char *fname);
 int  MSXDLLEXPORT MSXsavemsxfile(char *fname);
 int  MSXDLLEXPORT MSXreport(void);
 int  MSXDLLEXPORT MSXclose(void);
+int  MSXDLLEXPORT MSXENclose(void);
 
 int  MSXDLLEXPORT MSXgetindex(int type, char *id, int *index);
 int  MSXDLLEXPORT MSXgetIDlen(int type, int index, int *len);

--- a/src/solver/msxtoolkit.c
+++ b/src/solver/msxtoolkit.c
@@ -52,6 +52,38 @@ int    MSXfile_save(FILE *f);
 
 //=============================================================================
 
+int MSXDLLEXPORT   MSXENopen(const char *inpFile, const char *rptFile, const char *outFile)
+/*
+**  Purpose:
+**    pass-thru to open the EPANET toolkit system
+**
+**  Input:
+**    inpFile = name of the EPANET input file
+**    rptFile = name of the EPANET report file
+**    outFile = name of the EPANET binary file
+**
+**  Returns:
+**    an error code (or 0 for no error);
+*/
+{
+    int err = 0;
+    err = ENopen(inpFile, rptFile, outFile);
+    return err;
+}
+
+int MSXDLLEXPORT   MSXENclose(void)
+/*
+**  Purpose:
+**    pass-thru to open the EPANET toolkit system
+**
+*/
+{
+    int err = 0;
+    err = ENclose();
+    return err;
+}
+
+
 int  MSXDLLEXPORT  MSXopen(char *fname)
 /*
 **  Purpose:


### PR DESCRIPTION
When using the toolkit through python, I was not able to get the MSX DLL to open the EPANET network (ENopen). I added two pass-through functions, MSXENopen and MSXENclose which are exported as part of the MSX DLL, since ctypes wasn't seeing the related EPANET DLL, even though it (seemingly) should have. These two minor additions allow the network to be opened using the toolkit, and then all the MSX functions work correctly.