### PR TITLE
Update to build on both Intel and ARM MacOS systems

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,14 +26,17 @@ jobs:
             cmake_generator: -G "Unix Makefiles"
             continue-on-error: false
             alias: Linux
+            run_alias: Linux
           - os: macos-13
             cmake_generator: -G "Xcode"
             continue-on-error: false
             alias: intel-mac
+            run_alias: Darwin
           - os: macos-latest
             cmake_generator: -G "Xcode"
             continue-on-error: false
             alias: apple-silicon
+            run_alias: Darwin
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.continue-on-error }}
 
@@ -71,9 +74,9 @@ jobs:
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       if: ${{ matrix.os != 'windows-latest' }}
       run: |
-        chmod +x ./build/_CPack_Packages/${{ matrix.alias }}/ZIP/EPANETMSX-${{ env.BuildVersion }}-${{ matrix.alias }}/bin/runepanet
-        chmod +x ./build/_CPack_Packages/${{ matrix.alias }}/ZIP/EPANETMSX-${{ env.BuildVersion }}-${{ matrix.alias }}/bin/runepanetmsx
-        ./build/_CPack_Packages/${{ matrix.alias }}/ZIP/EPANETMSX-${{ env.BuildVersion }}-${{ matrix.alias }}/bin/runepanetmsx ./Examples/example.inp ./Examples/example.msx ./Examples/example.rpt ./Examples/example.out
+        chmod +x ./build/_CPack_Packages/${{ matrix.run_alias }}/ZIP/EPANETMSX-${{ env.BuildVersion }}-${{ matrix.run_alias }}/bin/runepanet
+        chmod +x ./build/_CPack_Packages/${{ matrix.run_alias }}/ZIP/EPANETMSX-${{ env.BuildVersion }}-${{ matrix.run_alias }}/bin/runepanetmsx
+        ./build/_CPack_Packages/${{ matrix.run_alias }}/ZIP/EPANETMSX-${{ env.BuildVersion }}-${{ matrix.run_alias }}/bin/runepanetmsx ./Examples/example.inp ./Examples/example.msx ./Examples/example.rpt ./Examples/example.out
       
     - name: Qualify darwin artifacts with os versions
       if: matrix.os == 'macos-13' || matrix.os == 'macos-14'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-13, macos-latest]
         include:
           - os: windows-latest
             cmake_generator: -G "Visual Studio 17 2022" -A "x64"
@@ -26,6 +26,10 @@ jobs:
             cmake_generator: -G "Unix Makefiles"
             continue-on-error: false
             alias: Linux
+          - os: macos-13
+            cmake_generator: -G "Xcode"
+            continue-on-error: false
+            alias: Darwin12
           - os: macos-latest
             cmake_generator: -G "Xcode"
             continue-on-error: false
@@ -41,7 +45,7 @@ jobs:
         submodules: true
 
     - name: Build OpenMP Binaries for MacOS via Homebrew
-      if: ${{ matrix.os == 'macos-latest' }}
+      if: ${{ matrix.os == 'macos-latest' || matrix.os == 'macos-13' }}
       run: |
         brew reinstall --build-from-source --formula ./shell/apple/libomp.rb
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,11 +29,11 @@ jobs:
           - os: macos-13
             cmake_generator: -G "Xcode"
             continue-on-error: false
-            alias: Darwin12
+            alias: intel-mac
           - os: macos-latest
             cmake_generator: -G "Xcode"
             continue-on-error: false
-            alias: Darwin
+            alias: apple-silicon
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.continue-on-error }}
 
@@ -75,6 +75,13 @@ jobs:
         chmod +x ./build/_CPack_Packages/${{ matrix.alias }}/ZIP/EPANETMSX-${{ env.BuildVersion }}-${{ matrix.alias }}/bin/runepanetmsx
         ./build/_CPack_Packages/${{ matrix.alias }}/ZIP/EPANETMSX-${{ env.BuildVersion }}-${{ matrix.alias }}/bin/runepanetmsx ./Examples/example.inp ./Examples/example.msx ./Examples/example.rpt ./Examples/example.out
       
+    - name: Qualify darwin artifacts with os versions
+      if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
+      run: |
+        cd build
+        for file in *.zip; do mv "$file" "${file%.zip}-${{ matrix.alias }}.zip"; done
+        for file in *.tar.gz; do mv "$file" "${file%.tar.gz}-${{ matrix.alias }}.tar.gz"; done
+        cd ..
 
     - name: Upload artifacts
       if: ${{ always() }}


### PR DESCRIPTION
Added a new entry to the matrix to generate Intel-x64 Mac build for older machines.