### PR TITLE
Replace contents of MSXutils_getTempName

### DIFF
--- a/src/solver/msxtoolkit.c
+++ b/src/solver/msxtoolkit.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <float.h>
 #include <stdlib.h>
+#include <locale.h>
 
 #include "msxtypes.h"
 #include "msxutils.h"                                                          
@@ -67,6 +68,7 @@ int MSXDLLEXPORT   MSXENopen(const char *inpFile, const char *rptFile, const cha
 */
 {
     int err = 0;
+    setlocale(LC_NUMERIC, "C");
     err = ENopen(inpFile, rptFile, outFile);
     return err;
 }

--- a/src/solver/msxutils.c
+++ b/src/solver/msxutils.c
@@ -45,31 +45,28 @@ char * MSXutils_getTempName(char *s)
 */
 {
 #ifdef WINDOWS
-    char *ptr;
-    char fname[L_tmpnam];
-    unsigned int i;
+    const int MAXFNAME = 259;
+    char* name = NULL;
 
-	// --- use tmpnam() function to create a temporary file name
-    tmpnam(fname);
-
-	// --- replace any '.' characters (they cause problems for some compilers)
-    for (i=0; i<strlen(fname); i++)
+    // --- use Windows _tempnam function to get a pointer to an
+    //     unused file name that begins with "msx"
+    strcpy(s, "");
+    name = _tempnam(NULL, "msx");
+    if (name)
     {
-	    if ( fname[i] == '.' ) fname[i] = '_';
+        // --- copy the file name to s
+        if (strlen(name) < MAXFNAME) strncpy(s, name, MAXFNAME);
+
+        // --- free the pointer returned by _tempnam
+        free(name);
     }
-
-	// --- set ptr to non-path portion of file name
-    ptr = strrchr(fname, '\\');
-    if ( ptr ) ++ptr;
-    else ptr = fname;
-
-	// --- use '.\' as path name to keep file in current directory
-	strcpy(s, ".\\");
-    strcat(s, ptr);
 #else
     // --- use system function mkstemp() to create a temporary file name
     strcpy(s, "msxXXXXXX");
-    mkstemp(s);
+    FILE* f = fdopen(mkstemp(s), "r");
+    if (f == NULL) strcpy(s, "");
+    else fclose(f);
+    remove(s);
 #endif
     return s;
 }


### PR DESCRIPTION
Fixes issue #19 . Also insures that MSX uses a dot as the decimal separator so that its files can be read correctly.